### PR TITLE
gamemode: Don't try calling parent's member functions

### DIFF
--- a/gamemode.h
+++ b/gamemode.h
@@ -11,8 +11,8 @@ class GameMode : public QObject {
 public:
     explicit GameMode(QObject *parent, QList<Character*> &plrs);
     virtual void initGame(Playfield *f, SamplePlayer *s)=0;
-    virtual QString name()=0;
-    virtual QString description()=0;
+    virtual QString name() const =0;
+    virtual QString description() const =0;
     virtual void startGame()=0;
     virtual void startRound()=0;
 signals:

--- a/gamemodebomberman.cpp
+++ b/gamemodebomberman.cpp
@@ -12,12 +12,12 @@ void GameModeBomberman::initGame(Playfield *f, SamplePlayer *s) {
     field->loadMapData("maps_bomberman.txt");
 }
 
-QString GameModeBomberman::name()
+QString GameModeBomberman::name() const
 {
     return "BOMBERMAN";
 }
 
-QString GameModeBomberman::description()
+QString GameModeBomberman::description() const
 {
     return "BLAST THEM AWAY!";
 }

--- a/gamemodebomberman.h
+++ b/gamemodebomberman.h
@@ -10,8 +10,8 @@ class GameModeBomberman : public GameMode
 public:
     explicit GameModeBomberman(QObject *parent, QList<Character*> &plrs);
     virtual void initGame(Playfield *f, SamplePlayer *s);
-    virtual QString name();
-    virtual QString description();
+    virtual QString name() const;
+    virtual QString description() const;
     virtual void startGame();
     virtual void startRound();
 signals:

--- a/gamemodeclassic.cpp
+++ b/gamemodeclassic.cpp
@@ -33,11 +33,11 @@ void GameModeClassic::initGame(Playfield *f, SamplePlayer *s) {
     field->loadMapData("maps_wow.txt");
 }
 
-QString GameModeClassic::name() {
+QString GameModeClassic::name() const {
     return "CLASSIC";
 }
 
-QString GameModeClassic::description() {
+QString GameModeClassic::description() const {
     return "Kill all enemies";
 }
 

--- a/gamemodeclassic.h
+++ b/gamemodeclassic.h
@@ -29,8 +29,8 @@ public:
     GameModeClassic(QObject *parent, QList<Character*> &plrs);
     ~GameModeClassic();
     virtual void initGame(Playfield *f, SamplePlayer *s);
-    virtual QString name();
-    virtual QString description();
+    virtual QString name() const;
+    virtual QString description() const;
     virtual void startGame();
     virtual void startRound();
 signals:

--- a/gamemodedeathmatch.cpp
+++ b/gamemodedeathmatch.cpp
@@ -16,11 +16,11 @@ void GameModeDeathmatch::initGame(Playfield *f, SamplePlayer *s) {
     field->loadMapData("maps_wow.txt");
 }
 
-QString GameModeDeathmatch::name() {
+QString GameModeDeathmatch::name() const {
     return "DEATHMATCH";
 }
 
-QString GameModeDeathmatch::description() {
+QString GameModeDeathmatch::description() const {
     return "Survive deathmatch 3 times to win";
 }
 

--- a/gamemodedeathmatch.h
+++ b/gamemodedeathmatch.h
@@ -12,8 +12,8 @@ class GameModeDeathmatch : public GameMode {
 public:
     explicit GameModeDeathmatch(QObject *parent, QList<Character*> &plrs);
     virtual void initGame(Playfield *f, SamplePlayer *s);
-    virtual QString name();
-    virtual QString description();
+    virtual QString name() const;
+    virtual QString description() const;
     virtual void startGame();
     virtual void startRound();
 signals:


### PR DESCRIPTION
I do not recall exactly what it was that triggered that change. I must have run into something while adding debug statements somewhere - and  I just like introducing those const flags everywhere, I admit.