### PR TITLE
sampleplayer: always initialize array of sounds

### DIFF
--- a/sampleplayer.cpp
+++ b/sampleplayer.cpp
@@ -50,14 +50,14 @@ SamplePlayer::~SamplePlayer() {
 void SamplePlayer::loadSample(QString file, gameSample sample) {
     //Load our WAV file from disk
     Mix_Chunk* sound = Mix_LoadWAV(file.toUtf8().data());
+    sounds[sample] = sound;
     if(sound == NULL) {
         qDebug() << Q_FUNC_INFO << "Unable to load WAV file: " << file << Mix_GetError();
-    } else {
-        sounds[sample] = sound;
     }
 }
 
 int SamplePlayer::playSound(gameSample sample, int loops) {
+    //qDebug() << "Playing sample " << sample;
     Mix_Chunk* sound = sounds.value(sample);
     if(!sound) {
         qDebug() << "Can't play sample " << sample;
@@ -68,6 +68,7 @@ int SamplePlayer::playSound(gameSample sample, int loops) {
     if(channel == -1) {
         qDebug() << "Unable to play sample file: " << Mix_GetError();
     }
+    //qDebug() << "Played sample " << sample << " sucessfully.";
     return channel;
 }
 
@@ -136,8 +137,16 @@ int SamplePlayer::worlukDied() {
     return playSound(GS_WORLUKDIED);
 }
 
+int SamplePlayer::worlukEscaped() {
+    return playSound(GS_WORLUKESCAPED);
+}
+
 int SamplePlayer::wizardDied() {
     return playSound(GS_WIZARDDIED);
+}
+
+int SamplePlayer::wizardEscaped() {
+    return playSound(GS_WIZARDESCAPED);
 }
 
 void SamplePlayer::setBackgroundInterval(int ms) {

--- a/sampleplayer.h
+++ b/sampleplayer.h
@@ -25,7 +25,9 @@ enum gameSample {
     GS_BACKGROUND_3,
     GS_BACKGROUND_WORLUK,
     GS_WORLUKDIED,
-    GS_WIZARDDIED
+    GS_WIZARDDIED,
+    GS_WIZARDESCAPED,
+    GS_WORLUKESCAPED
 };
 
 class SamplePlayer : public QObject {
@@ -52,6 +54,8 @@ public slots:
     int enemyVisible();
     int worlukDied();
     int wizardDied();
+    int worlukEscaped();
+    int wizardEscaped();
 private slots:
     void nextBgSound();
 private:


### PR DESCRIPTION
Found this locally, actually thought to have sent a PR about it already. All entries of the sounds array should be initialized. The change was triggered by the crash when the worluk escapes - it was not because of the missing sound, though :-/