### PR TITLE
Replace deprecated qrand usage

### DIFF
--- a/characters/enemycharacter.cpp
+++ b/characters/enemycharacter.cpp
@@ -1,4 +1,5 @@
 #include "enemycharacter.h"
+#include <QRandomGenerator>
 
 EnemyCharacter::EnemyCharacter(QObject *parent, PlayfieldInfo *pfinfo, SamplePlayer *smp) : Character(parent, pfinfo, smp) {
     setSpeedScale(1);
@@ -18,7 +19,7 @@ void EnemyCharacter::tick(float dt) {
 
         if((cd.x() > 0 && !mt->e()) || (cd.x() < 0 && !mt->w()) ) {
 //            qDebug() << Q_FUNC_INFO << "e or w wall, turning";
-            if(qrand() & 1) {
+            if(QRandomGenerator::global()->bounded(2)) {
                 if(mt->s()) {
                     cd = QPoint(0,1);
                 } else {
@@ -37,7 +38,7 @@ void EnemyCharacter::tick(float dt) {
                 (cd.y() < 0 && !mt->n())
                 ) {
  //           qDebug() << Q_FUNC_INFO << "s or n wall, turning";
-            if(qrand() & 1) {
+            if(QRandomGenerator::global()->bounded(2)) {
                 if(mt->e()) {
                     cd = QPoint(1,0);
                 } else {
@@ -53,14 +54,14 @@ void EnemyCharacter::tick(float dt) {
         }
 
         if(cd == controlDir && lastTurnInTile != mt) { // No corned turn happened
-            if((qrand() & 5)==0) { // Random turn
-                if(cd.x() && mt->s() && (qrand() & 1)) {
+            if((QRandomGenerator::global()->generate() & 5)==0) { // Random turn
+                if(cd.x() && mt->s() && QRandomGenerator::global()->bounded(2)) {
                     cd = QPoint(0,1);
-                } else if(cd.x() && mt->n() && (qrand() & 1)) {
+                } else if(cd.x() && mt->n() && QRandomGenerator::global()->bounded(2)) {
                     cd = QPoint(0,-1);
-                } else if(cd.y() && mt->w() && (qrand() & 1)) {
+                } else if(cd.y() && mt->w() && QRandomGenerator::global()->bounded(2)) {
                     cd = QPoint(-1,0);
-                } else if(cd.y() && mt->e() && (qrand() & 1)) {
+                } else if(cd.y() && mt->e() && QRandomGenerator::global()->bounded(2)) {
                     cd = QPoint(1,0);
                 }
             }
@@ -70,7 +71,7 @@ void EnemyCharacter::tick(float dt) {
         }
         Q_ASSERT(cd.manhattanLength() > 0);
         setDirection(cd);
-        if(shootingProbability > 0 && canShoot && (qrand() % shootingProbability==0))
+        if(shootingProbability > 0 && canShoot && (QRandomGenerator::global()->bounded(shootingProbability)==0))
             fireWeapon();
     }
     if(!dead) {

--- a/characters/stealthcharacter.cpp
+++ b/characters/stealthcharacter.cpp
@@ -1,4 +1,5 @@
 #include "stealthcharacter.h"
+#include <QRandomGenerator>
 
 StealthCharacter::StealthCharacter(QObject *parent,
                                    PlayfieldInfo *pfinfo,
@@ -16,7 +17,7 @@ StealthCharacter::StealthCharacter(QObject *parent,
 void StealthCharacter::tileEntered(MapTile *mt) {
     EnemyCharacter::tileEntered(mt);
     bool oldStealthMode = stealthMode;
-    if(stealthProbability > 0 && qrand()%stealthProbability==0) {
+    if(stealthProbability > 0 && QRandomGenerator::global()->bounded(stealthProbability)==0) {
         if(!stealthMode) {
             if(!seesPlayer())
                 stealthMode = true;

--- a/playfield.cpp
+++ b/playfield.cpp
@@ -2,6 +2,7 @@
 #include "player.h"
 #include "characters/enemycharacter.h"
 #include <QFile>
+#include <QRandomGenerator>
 #include <QTextStream>
 #include "maptile.h"
 Playfield::Playfield(QObject *parent, QList<Character*> &chars) : QObject(parent), _scene(), characters(chars) {
@@ -226,11 +227,11 @@ SpawnTile* Playfield::spawnPoint(int num) {
 }
 
 void Playfield::removeRandomWall() {
-    int x = 2+qrand() % (MAPW-3);
-    int y = 2+qrand() % (MAPH-4);
+    int x = 2 + QRandomGenerator::global()->bounded(MAPW - 3);
+    int y = 2 + QRandomGenerator::global()->bounded(MAPH - 4);
     MapTile *mt = tileAt(TilePos(x,y));
     Q_ASSERT(mt);
-    if(qrand() % 2 == 1) {
+    if(QRandomGenerator::global()->bounded(2) == 1) {
         if(mt->walls() & MapTile::MT_W)
             mt->setWalls(mt->walls() - MapTile::MT_W);
     } else {
@@ -279,8 +280,8 @@ void Playfield::setMode(int m) {
 
 MapTile *Playfield::randomTile(bool notCloseToCharacters) {
     //qDebug() << Q_FUNC_INFO << "notCloseToCharacters:" << notCloseToCharacters << " characters.size():" << characters.size();
-    int x = 1+qrand() % (MAPW-2);
-    int y = 1+qrand() % (MAPH-2);
+    int x = 1 + QRandomGenerator::global()->bounded(MAPW - 2);
+    int y = 1 + QRandomGenerator::global()->bounded(MAPH - 2);
     //qDebug() << "characters has size " << characters.size();
     if(notCloseToCharacters) {
         for(int minRange = 4; minRange >0;minRange--) {
@@ -306,8 +307,8 @@ MapTile *Playfield::randomTile(bool notCloseToCharacters) {
                 return tileAt(TilePos(x,y));
             }
             //qDebug() << "random position";
-            x = 1+qrand() % (MAPW-2);
-            y = 1+qrand() % (MAPH-2);
+            x = 1 + QRandomGenerator::global()->bounded(MAPW - 2);
+            y = 1 + QRandomGenerator::global()->bounded(MAPH - 2);
         }
     }
     //qDebug() << "returning " << x << y;


### PR DESCRIPTION
Built against a Qt6 library, the qrand() invocations are referred to as deprecated. This patch addresses this.
On a mac on its own this does not build directly against master, the wiimote dependency is in its way, but if this passes the CI on Linux (update: I now know that it does :-) ) then it should be fine.