### PR TITLE
Make cwiid Wiimote support optional

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -13,8 +13,10 @@ MainWindow::MainWindow(QWidget *parent) : QGraphicsView(parent), samples(), fiel
     mainTimer.setInterval(1000 * 1.0/60.0);
     mainTimer.start();
     time.start();
+#ifdef HAVE_CWIID
     connect(&wmFinder, SIGNAL(wiimoteFound(WiiMote*)), this, SLOT(wiimoteFound(WiiMote*)));
     wmFinder.scanMote();
+#endif
     playerSelectionMenu = 0;
     gameSelectionMenu = 0;
     roundEndScreen = 0;
@@ -54,7 +56,9 @@ void MainWindow::loopTimeout() {
     foreach(Character *p, characters)
         p->tick(dt);
     field.tick(dt);
+#ifdef HAVE_CWIID
     wmFinder.pollMotes();
+#endif
 }
 
 void MainWindow::keyPressEvent (QKeyEvent * e) {
@@ -125,8 +129,10 @@ void MainWindow::setupPlayer(Player* p, QObject *controller) {
 }
 
 void MainWindow::stopGame() {
+#ifdef HAVE_CWIID
     wmFinder.stopScan();
     wmFinder.quit();
+#endif
 }
 
 void MainWindow::keyReleaseEvent (QKeyEvent * e) {
@@ -146,6 +152,7 @@ void MainWindow::keyReleaseEvent (QKeyEvent * e) {
         e->ignore();
 }
 
+#ifdef HAVE_CWIID
 void MainWindow::wiimoteFound(WiiMote *wm) {
     if(!wm) {
         return;
@@ -159,6 +166,7 @@ void MainWindow::wiimoteFound(WiiMote *wm) {
     setupPlayer(p, wm);
     connect(wm, SIGNAL(buttonPressed(int)), this, SLOT(wiimoteButtonPressed(int)));
 }
+#endif
 
 void MainWindow::resizeEvent(QResizeEvent *event) {
     fitInView(-32,-36,352,236, Qt::KeepAspectRatio);
@@ -170,7 +178,9 @@ void MainWindow::wiimoteButtonPressed(int buttons) {
             scene()->removeItem(playerSelectionMenu);
             delete playerSelectionMenu;
             playerSelectionMenu = 0;
+#ifdef HAVE_CWIID
             wmFinder.stopScan();
+#endif
             gameState = GS_GAME_SELECT; // Enter game select
             gameSelectionMenu = new GameSelectionMenu(this, characters);
             connect(gameSelectionMenu, SIGNAL(gameModeSelected(GameMode*)), this, SLOT(gameModeSelected(GameMode*)));
@@ -205,10 +215,12 @@ void MainWindow::wiimoteButtonPressed(int buttons) {
 
 void MainWindow::resetPlayers() {
     if(gameState != 0) return;
+#ifdef HAVE_CWIID
     while(!wmFinder.wiimotes.isEmpty()) {
         WiiMote *m = wmFinder.wiimotes.first();
         wmFinder.freeMote(m);
     }
+#endif
     while(!characters.isEmpty()) {
         Character *c= characters.first();
         Player *p = qobject_cast<Player*>(c);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -11,8 +11,10 @@
 #include <QFontDatabase>
 #include "playfield.h"
 //#include "character.h"
+#ifdef HAVE_CWIID
 #include "wiimote.h"
 #include "wiimotefinder.h"
+#endif
 #include "gamemenu.h"
 #include "player.h"
 #include "sampleplayer.h"
@@ -45,7 +47,9 @@ public:
     void resetPlayers();
 public slots:
     void loopTimeout();
+#ifdef HAVE_CWIID
     void wiimoteFound(WiiMote *wm);
+#endif
     void wiimoteButtonPressed(int buttons);
     void gameModeSelected(GameMode *gm);
     void showRoundEnd(Player *winner);
@@ -65,7 +69,9 @@ private:
     QTimer mainTimer;
     QTime time;
     QPoint controllerDir;
+#ifdef HAVE_CWIID
     WiimoteFinder wmFinder;
+#endif
     PlayerSelectionMenu *playerSelectionMenu;
     GameSelectionMenu *gameSelectionMenu;
     RoundEndScreen *roundEndScreen;

--- a/wow.pro
+++ b/wow.pro
@@ -10,7 +10,19 @@ QT += widgets
 TARGET = wow
 TEMPLATE = app
 CONFIG   += link_pkgconfig
-PKGCONFIG += cwiid sdl2
+PKGCONFIG += sdl2
+
+!contains(CONFIG, no_cwiid) {
+    packagesExist(cwiid) {
+        PKGCONFIG += cwiid
+        DEFINES += HAVE_CWIID
+        CONFIG += have_cwiid
+    } else {
+        message("cwiid not found; Wiimote support disabled")
+    }
+} else {
+    message("cwiid disabled; Wiimote support disabled")
+}
 
 LIBS += -lSDL2_mixer
 
@@ -21,8 +33,6 @@ SOURCES += main.cpp\
     playfieldinfo.cpp \
     maptile.cpp \
     lazorbeam.cpp \
-    wiimote.cpp \
-    wiimotefinder.cpp \
     player.cpp \
     gamemenu.cpp \
     sampleplayer.cpp \
@@ -55,8 +65,6 @@ HEADERS  += mainwindow.h \
     playfieldinfo.h \
     maptile.h \
     lazorbeam.h \
-    wiimote.h \
-    wiimotefinder.h \
     player.h \
     gamemenu.h \
     sampleplayer.h \
@@ -88,3 +96,11 @@ FORMS    += mainwindow.ui
 OTHER_FILES += \
     maps_wow.txt \
     maps_bomberman.txt
+
+have_cwiid {
+    SOURCES += wiimote.cpp \
+        wiimotefinder.cpp
+
+    HEADERS += wiimote.h \
+        wiimotefinder.h
+}


### PR DESCRIPTION
On macOS and Windows the wiimote support is not available (should actually look into that) and this patch makes sure that a build also builds without it - or that it does not fail because of wiimote not being available,  I should say. This patch in isolation is not tested since needed together with #11 on my Qt6 macOS setup, but if it passes the CI, I am very confident about it.