### PR TITLE
Fix reset crash before map load

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -212,8 +212,11 @@ void MainWindow::resetPlayers() {
     while(!characters.isEmpty()) {
         Character *c= characters.first();
         Player *p = qobject_cast<Player*>(c);
-        if(p)
-            field.spawnPoint(p->number())->setUsedByPlayer(false);
+        if(p) {
+            SpawnTile *spawn = field.spawnPoint(p->number());
+            if(spawn)
+                spawn->setUsedByPlayer(false);
+        }
         characters.removeOne(c);
         c->deleteLater();
     }


### PR DESCRIPTION
Resetting players from the selection screen can happen before any map has been loaded. In that state the player list may contain a keyboard player, but the playfield has no spawn tiles yet. Guard the spawn lookup before clearing the tile's used state so pressing reset cannot dereference a null spawn tile.