### PR TITLE
Fix Worluk escape crash in release builds

### DIFF
--- a/gamemodeclassic.cpp
+++ b/gamemodeclassic.cpp
@@ -369,7 +369,8 @@ void GameModeClassic::setupNewEnemy(EnemyCharacter *c) {
 void GameModeClassic::worlukEscaped() {
     qDebug() << Q_FUNC_INFO << "worlukEscaped";
     Q_ASSERT(enemyCharacters().size()==1 && worluk);
-    Q_ASSERT(characters.removeOne(worluk));
+    bool removed = characters.removeOne(worluk);
+    Q_ASSERT(removed);
     worluk->deleteLater();
     worluk = 0;
     field->setMode(false);


### PR DESCRIPTION
The Worluk escape path removed the Worluk from the shared character list inside Q_ASSERT(characters.removeOne(worluk)). In release builds Q_ASSERT is compiled out, so the removal never ran. The Worluk was then scheduled for deletion while a stale pointer remained in characters, and the next main timer tick could dereference it and crash. Perform the removal unconditionally and assert the result separately.

This caused a crash, very frustrating after successfully mastering the first set of levels :-)